### PR TITLE
SSASSF-2764 Cybersecurity updates: Add config-driven legacy encryption with automatic decryption fallback

### DIFF
--- a/lib/secure_api/api_token/creation.rb
+++ b/lib/secure_api/api_token/creation.rb
@@ -13,6 +13,8 @@ module ApiToken
     end
 
     def encrypted_hex
+      return legacy_encrypted_hex if legacy_encryption_enabled?
+
       encrypter = OpenSSL::Cipher.new(cipher_name)
       encrypter.encrypt
       encrypter.key = key
@@ -30,6 +32,18 @@ module ApiToken
       
       # Prepend IV to the encrypted data (IV is not secret, only key is)
       iv + encrypted
+    end
+
+    # Legacy encryption: static IV from salt and no prepended IV/auth tag.
+    def legacy_encrypted_hex
+      encrypter = OpenSSL::Cipher.new(legacy_cipher_name)
+      encrypter.encrypt
+      encrypter.key = legacy_key
+      encrypter.iv = salt
+
+      encrypted = encrypter.update new_token
+      encrypted << encrypter.final
+      encrypted
     end
 
     def new_token

--- a/lib/secure_api/api_token/defaults.rb
+++ b/lib/secure_api/api_token/defaults.rb
@@ -61,5 +61,29 @@ module ApiToken
     def auth_tag_length
       SecureApi.configuration.secure_api_auth_tag_length
     end
+
+    # Enables legacy token creation format (CBC + static IV from salt).
+    # @return [Boolean]
+    def legacy_encryption_enabled?
+      SecureApi.configuration.secure_api_enable_legacy_encryption
+    end
+
+    # Legacy cipher for backward-compatible decryption/encryption.
+    # @return [String]
+    def legacy_cipher_name
+      SecureApi.configuration.secure_api_legacy_cipher_name
+    end
+
+    # PBKDF2 iterations used by legacy SHA1 key derivation.
+    # @return [Integer]
+    def legacy_key_iterations
+      SecureApi.configuration.secure_api_legacy_key_iterations
+    end
+
+    # Legacy key derivation used by pre-GCM tokens.
+    # @return [String]
+    def legacy_key
+      OpenSSL::PKCS5.pbkdf2_hmac_sha1(pass_phrase, salt, legacy_key_iterations, key_length)
+    end
   end
 end

--- a/lib/secure_api/api_token/validation.rb
+++ b/lib/secure_api/api_token/validation.rb
@@ -5,6 +5,9 @@ module ApiToken
   module Validation
     private
 
+    # Decodes a URL-safe Base64 token payload.
+    # @param url_token [String, nil] URL-safe Base64 encoded token value
+    # @return [String, nil] Raw decoded bytes or nil when input is invalid
     def decode_url_token(url_token)
       return nil unless url_token
       Base64.urlsafe_decode64(url_token)
@@ -12,33 +15,44 @@ module ApiToken
       nil
     end
 
+    # Decrypts a token with current format first and legacy format as fallback.
+    # @param url_token [String, nil] URL-safe Base64 encoded token value
+    # @return [String, nil] Decrypted token payload or nil when decryption fails
     def decrypted_token(url_token)
       hex_string = decode_url_token(url_token)
       return nil unless hex_string
-      
-      # Extract IV from the beginning of the data
+
+      decrypted = decrypt_current(hex_string)
+      return decrypted if decrypted
+
+      decrypt_legacy(hex_string)
+    end
+
+    # Decrypts a payload using the current format where IV is prepended.
+    # @param hex_string [String] Raw decoded token payload bytes
+    # @return [String, nil] Decrypted plaintext or nil when decryption fails
+    def decrypt_current(hex_string)
       iv_length = OpenSSL::Cipher.new(cipher_name).iv_len
       return nil if hex_string.bytesize < iv_length
-      
+
       iv = hex_string[0...iv_length]
       remaining_data = hex_string[iv_length..-1]
-      
-      # Build decrypter with extracted IV
+
       decrypter = OpenSSL::Cipher.new(cipher_name)
       decrypter.decrypt
       decrypter.key = key
       decrypter.iv = iv
-      
-      # For GCM mode, extract and set the authentication tag
+
       if decrypter.authenticated?
         return nil if remaining_data.bytesize < auth_tag_length
-        ciphertext = remaining_data[0...-auth_tag_length]
+
         auth_tag = remaining_data[-auth_tag_length..-1]
         decrypter.auth_tag = auth_tag
+        ciphertext = remaining_data[0...-auth_tag_length]
       else
         ciphertext = remaining_data
       end
-      
+
       plain = decrypter.update ciphertext
       plain << decrypter.final
       plain
@@ -46,6 +60,27 @@ module ApiToken
       nil
     end
 
+    # Decrypts a payload using the legacy format with static IV from salt.
+    # @param hex_string [String] Raw decoded token payload bytes
+    # @return [String, nil] Decrypted plaintext or nil when decryption fails
+    def decrypt_legacy(hex_string)
+      decrypter = OpenSSL::Cipher.new(legacy_cipher_name)
+      return nil unless salt.bytesize == decrypter.iv_len
+
+      decrypter.decrypt
+      decrypter.key = legacy_key
+      decrypter.iv = salt
+
+      plain = decrypter.update hex_string
+      plain << decrypter.final
+      plain
+    rescue OpenSSL::Cipher::CipherError, ArgumentError
+      nil
+    end
+
+    # Verifies token timestamp is within allowed tolerance.
+    # @param clear_token [String] Decrypted token payload
+    # @return [Boolean] True when token age is within tolerance
     def within_time_tolerance(clear_token)
       clear_token[/#{prefix}([0-9]+)#{suffix}/]
       token_time = $1 || 0

--- a/lib/secure_api/configuration.rb
+++ b/lib/secure_api/configuration.rb
@@ -23,6 +23,18 @@ module SecureApi
     # return [Integer]
     attr_accessor :secure_api_auth_tag_length
 
+    # Enable legacy token encryption (AES-256-CBC + PBKDF2-HMAC-SHA1)
+    # @return [Boolean]
+    attr_accessor :secure_api_enable_legacy_encryption
+
+    # Legacy cipher algorithm used before migration to GCM
+    # @return [String]
+    attr_accessor :secure_api_legacy_cipher_name
+
+    # PBKDF2 iteration count used for legacy SHA1 key derivation
+    # @return [Integer]
+    attr_accessor :secure_api_legacy_key_iterations
+
     def initialize
       reset
     end
@@ -37,6 +49,9 @@ module SecureApi
       @secure_api_key_iterations = 300_000
       @secure_api_key_length = 32
       @secure_api_auth_tag_length = 16
+      @secure_api_enable_legacy_encryption = false
+      @secure_api_legacy_cipher_name = 'AES-256-CBC'
+      @secure_api_legacy_key_iterations = 20_000
       nil
     end
   end

--- a/test/api_token_test.rb
+++ b/test/api_token_test.rb
@@ -8,6 +8,7 @@ class ApiTokenTest < Minitest::Test
       config.secure_api_cipher_name = 'AES-256-GCM'
       config.secure_api_key_iterations = 200_000
       config.secure_api_key_length = 32
+      config.secure_api_enable_legacy_encryption = false
     end
     @token = ::ApiToken.create
   end
@@ -49,5 +50,50 @@ class ApiTokenTest < Minitest::Test
     ApiToken.stub(:timestamp, eleven_minutes_from_now) do
       refute ApiToken.valid?(@token)
     end
+  end
+
+  def test_legacy_encryption_and_decryption_when_enabled
+    SecureApi.configure do |config|
+      config.secure_api_pass_phrase = 'test pass phrase'
+      config.secure_api_salt = '0123456789014444'
+      config.secure_api_enable_legacy_encryption = true
+    end
+
+    legacy_token = ::ApiToken.create
+    assert ::ApiToken.valid?(legacy_token)
+  end
+
+  def test_legacy_decryption_fallback_works_without_config
+    SecureApi.configure do |config|
+      config.secure_api_pass_phrase = 'test pass phrase'
+      config.secure_api_salt = '0123456789014444'
+      config.secure_api_enable_legacy_encryption = true
+    end
+    legacy_token = ::ApiToken.create
+
+    SecureApi.configure do |config|
+      config.secure_api_pass_phrase = 'test pass phrase'
+      config.secure_api_salt = '0123456789014444'
+      config.secure_api_cipher_name = 'AES-256-GCM'
+      config.secure_api_key_iterations = 200_000
+      config.secure_api_key_length = 32
+      config.secure_api_enable_legacy_encryption = false
+    end
+
+    assert ::ApiToken.valid?(legacy_token)
+  end
+
+  def test_new_encryption_remains_configurable
+    SecureApi.configure do |config|
+      config.secure_api_pass_phrase = 'test pass phrase'
+      config.secure_api_salt = '0123456789014444'
+      config.secure_api_enable_legacy_encryption = false
+      config.secure_api_cipher_name = 'AES-256-GCM'
+      config.secure_api_key_iterations = 200_000
+      config.secure_api_key_length = 32
+    end
+
+    token = ::ApiToken.create
+    assert ::ApiToken.valid?(token)
   end
 end


### PR DESCRIPTION
Chnages:
- Added secure_api_enable_legacy_encryption config flag (default: false)
- Added legacy cipher/key settings (AES-256-CBC, PBKDF2-HMAC-SHA1, 20k iterations)
- Decryption always tries current (AES-256-GCM) first, falls back to legacy automatically
- Supports rolling deployments where servers run mixed encryption versions