### PR TITLE
SSASSF-2982: Fix token expiration rule

### DIFF
--- a/lib/secure_api/api_token/validation.rb
+++ b/lib/secure_api/api_token/validation.rb
@@ -85,7 +85,7 @@ module ApiToken
       clear_token[/#{prefix}([0-9]+)#{suffix}/]
       token_time = $1 || 0
       elapsed_time = timestamp.to_i - token_time.to_i
-      elapsed_time < time_tolerance_seconds
+      elapsed_time >= 0 && elapsed_time < time_tolerance_seconds
     end
   end
 end

--- a/lib/secure_api/api_token/validation.rb
+++ b/lib/secure_api/api_token/validation.rb
@@ -85,7 +85,7 @@ module ApiToken
       clear_token[/#{prefix}([0-9]+)#{suffix}/]
       token_time = $1 || 0
       elapsed_time = timestamp.to_i - token_time.to_i
-      elapsed_time >= 0 && elapsed_time < time_tolerance_seconds
+      elapsed_time.abs < time_tolerance_seconds
     end
   end
 end

--- a/test/api_token_test.rb
+++ b/test/api_token_test.rb
@@ -52,6 +52,13 @@ class ApiTokenTest < Minitest::Test
     end
   end
 
+  def test_a_token_with_a_future_timestamp_is_invalid
+    twenty_minutes_ago = Time.now.utc.to_i - (60 * 20)
+    ApiToken.stub(:timestamp, twenty_minutes_ago) do
+      refute ApiToken.valid?(@token)
+    end
+  end
+
   def test_legacy_encryption_and_decryption_when_enabled
     SecureApi.configure do |config|
       config.secure_api_pass_phrase = 'test pass phrase'

--- a/test/api_token_test.rb
+++ b/test/api_token_test.rb
@@ -52,10 +52,17 @@ class ApiTokenTest < Minitest::Test
     end
   end
 
-  def test_a_token_with_a_future_timestamp_is_invalid
+  def test_a_token_with_a_future_timestamp_beyond_tolerance_is_invalid
     twenty_minutes_ago = Time.now.utc.to_i - (60 * 20)
     ApiToken.stub(:timestamp, twenty_minutes_ago) do
       refute ApiToken.valid?(@token)
+    end
+  end
+
+  def test_a_token_with_a_future_timestamp_within_tolerance_is_valid
+    nine_minutes_ago = Time.now.utc.to_i - (60 * 9)
+    ApiToken.stub(:timestamp, nine_minutes_ago) do
+      assert ApiToken.valid?(@token)
     end
   end
 


### PR DESCRIPTION
Fix for:
https://jira.dentsplysirona.com/browse/SSASSF-2982 "Tokens with future timestamps ignore the token expiration 10 minute rule."